### PR TITLE
Add support for the conventional annotation resolved.

### DIFF
--- a/bot/formatting.go
+++ b/bot/formatting.go
@@ -82,6 +82,9 @@ func FormatAlerts(alerts []*alertmanager.Alert, labels bool) (string, string) {
 		if v, ok := a.Annotations["summary"]; ok {
 			summary = string(v)
 		}
+		if v, ok := a.Annotations["resolved"]; ok && status == "resolved" {
+			summary = string(v)
+		}
 
 		alertName := ""
 		if v, ok := a.Labels["alertname"]; ok {


### PR DESCRIPTION
Small fix to use the `resolved` annotation if the annotation is available, when issuing a message about an alert resolving itself.